### PR TITLE
JKNIG-1-Cover controller layer with Spring Web layer tests

### DIFF
--- a/src/test/java/ai/junior/developer/controller/FilesControllerTest.java
+++ b/src/test/java/ai/junior/developer/controller/FilesControllerTest.java
@@ -1,0 +1,47 @@
+package ai.junior.developer.controller;
+
+import ai.junior.developer.service.FilesService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class FilesControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private FilesService filesService;
+
+    @InjectMocks
+    private FilesController filesController;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        this.mockMvc = MockMvcBuilders.standaloneSetup(filesController).build();
+    }
+
+    @Test
+    void testListFiles() throws Exception {
+        List<String> mockFiles = Arrays.asList("file1.txt", "file2.txt");
+        when(filesService.listFiles()).thenReturn(mockFiles);
+
+        this.mockMvc.perform(get("/api/files/listFiles"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(content().json("[\"file1.txt\", \"file2.txt\"]"));
+    }
+}

--- a/src/test/java/ai/junior/developer/controller/FilesControllerTest.java
+++ b/src/test/java/ai/junior/developer/controller/FilesControllerTest.java
@@ -1,14 +1,12 @@
 package ai.junior.developer.controller;
 
 import ai.junior.developer.service.FilesService;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.springframework.http.MediaType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.util.Arrays;
 import java.util.List;
@@ -18,21 +16,15 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@WebMvcTest(FilesController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class FilesControllerTest {
 
+    @Autowired
     private MockMvc mockMvc;
 
-    @Mock
+    @MockBean
     private FilesService filesService;
-
-    @InjectMocks
-    private FilesController filesController;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-        this.mockMvc = MockMvcBuilders.standaloneSetup(filesController).build();
-    }
 
     @Test
     void testListFiles() throws Exception {
@@ -41,7 +33,7 @@ class FilesControllerTest {
 
         this.mockMvc.perform(get("/api/files/listFiles"))
             .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(content().contentType("application/json"))
             .andExpect(content().json("[\"file1.txt\", \"file2.txt\"]"));
     }
 }

--- a/src/test/java/ai/junior/developer/controller/GitControllerTest.java
+++ b/src/test/java/ai/junior/developer/controller/GitControllerTest.java
@@ -1,0 +1,40 @@
+package ai.junior.developer.controller;
+
+import ai.junior.developer.service.GitService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class GitControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private GitService gitService;
+
+    @InjectMocks
+    private GitController gitController;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        this.mockMvc = MockMvcBuilders.standaloneSetup(gitController).build();
+    }
+
+    @Test
+    void testCloneRepository() throws Exception {
+        doNothing().when(gitService).cloneRepository("http://example-repo-url");
+
+        mockMvc.perform(post("/api/git/clone")
+                .param("repoUrl", "http://example-repo-url"))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/ai/junior/developer/controller/GitControllerTest.java
+++ b/src/test/java/ai/junior/developer/controller/GitControllerTest.java
@@ -1,33 +1,26 @@
 package ai.junior.developer.controller;
 
 import ai.junior.developer.service.GitService;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@WebMvcTest(GitController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class GitControllerTest {
 
+    @Autowired
     private MockMvc mockMvc;
 
-    @Mock
+    @MockBean
     private GitService gitService;
-
-    @InjectMocks
-    private GitController gitController;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-        this.mockMvc = MockMvcBuilders.standaloneSetup(gitController).build();
-    }
 
     @Test
     void testCloneRepository() throws Exception {

--- a/src/test/java/ai/junior/developer/controller/GitHubControllerTest.java
+++ b/src/test/java/ai/junior/developer/controller/GitHubControllerTest.java
@@ -1,33 +1,26 @@
 package ai.junior.developer.controller;
 
 import ai.junior.developer.service.GitHubService;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@WebMvcTest(GitHubController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class GitHubControllerTest {
 
+    @Autowired
     private MockMvc mockMvc;
 
-    @Mock
+    @MockBean
     private GitHubService githubService;
-
-    @InjectMocks
-    private GitHubController githubController;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-        this.mockMvc = MockMvcBuilders.standaloneSetup(githubController).build();
-    }
 
     @Test
     void testCreatePullRequest() throws Exception {

--- a/src/test/java/ai/junior/developer/controller/GitHubControllerTest.java
+++ b/src/test/java/ai/junior/developer/controller/GitHubControllerTest.java
@@ -1,0 +1,41 @@
+package ai.junior.developer.controller;
+
+import ai.junior.developer.service.GitHubService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class GitHubControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private GitHubService githubService;
+
+    @InjectMocks
+    private GitHubController githubController;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        this.mockMvc = MockMvcBuilders.standaloneSetup(githubController).build();
+    }
+
+    @Test
+    void testCreatePullRequest() throws Exception {
+        doNothing().when(githubService).createPullRequest("Test PR", "Description");
+
+        mockMvc.perform(post("/api/github/pr")
+                .param("title", "Test PR")
+                .param("description", "Description"))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/ai/junior/developer/controller/JiraControllerTest.java
+++ b/src/test/java/ai/junior/developer/controller/JiraControllerTest.java
@@ -1,33 +1,26 @@
 package ai.junior.developer.controller;
 
 import ai.junior.developer.service.JiraService;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@WebMvcTest(JiraController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class JiraControllerTest {
 
+    @Autowired
     private MockMvc mockMvc;
 
-    @Mock
+    @MockBean
     private JiraService jiraService;
-
-    @InjectMocks
-    private JiraController jiraController;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-        this.mockMvc = MockMvcBuilders.standaloneSetup(jiraController).build();
-    }
 
     @Test
     void testWebhook() throws Exception {

--- a/src/test/java/ai/junior/developer/controller/JiraControllerTest.java
+++ b/src/test/java/ai/junior/developer/controller/JiraControllerTest.java
@@ -1,0 +1,42 @@
+package ai.junior.developer.controller;
+
+import ai.junior.developer.service.JiraService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class JiraControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private JiraService jiraService;
+
+    @InjectMocks
+    private JiraController jiraController;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        this.mockMvc = MockMvcBuilders.standaloneSetup(jiraController).build();
+    }
+
+    @Test
+    void testWebhook() throws Exception {
+        doNothing().when(jiraService).validateRequest("requestBody", "signature");
+        doNothing().when(jiraService).webhook("requestBody");
+
+        mockMvc.perform(post("/api/jira/webhook")
+                .header("X-Hub-Signature", "signature")
+                .content("requestBody"))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/ai/junior/developer/controller/MavenControllerTest.java
+++ b/src/test/java/ai/junior/developer/controller/MavenControllerTest.java
@@ -1,33 +1,26 @@
 package ai.junior.developer.controller;
 
 import ai.junior.developer.service.MavenService;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@WebMvcTest(MavenController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class MavenControllerTest {
 
+    @Autowired
     private MockMvc mockMvc;
 
-    @Mock
+    @MockBean
     private MavenService mavenService;
-
-    @InjectMocks
-    private MavenController mavenController;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-        this.mockMvc = MockMvcBuilders.standaloneSetup(mavenController).build();
-    }
 
     @Test
     void testRunCleanInstall() throws Exception {

--- a/src/test/java/ai/junior/developer/controller/MavenControllerTest.java
+++ b/src/test/java/ai/junior/developer/controller/MavenControllerTest.java
@@ -1,0 +1,40 @@
+package ai.junior.developer.controller;
+
+import ai.junior.developer.service.MavenService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class MavenControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private MavenService mavenService;
+
+    @InjectMocks
+    private MavenController mavenController;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        this.mockMvc = MockMvcBuilders.standaloneSetup(mavenController).build();
+    }
+
+    @Test
+    void testRunCleanInstall() throws Exception {
+        when(mavenService.runCleanInstall("myProject")).thenReturn("Successful Installation");
+
+        mockMvc.perform(get("/api/build/run")
+                .param("project", "myProject"))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/ai/junior/developer/controller/RunControllerTest.java
+++ b/src/test/java/ai/junior/developer/controller/RunControllerTest.java
@@ -1,33 +1,26 @@
 package ai.junior.developer.controller;
 
 import ai.junior.developer.service.RunService;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@WebMvcTest(RunController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class RunControllerTest {
 
+    @Autowired
     private MockMvc mockMvc;
 
-    @Mock
+    @MockBean
     private RunService runService;
-
-    @InjectMocks
-    private RunController runController;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-        this.mockMvc = MockMvcBuilders.standaloneSetup(runController).build();
-    }
 
     @Test
     void testRun() throws Exception {

--- a/src/test/java/ai/junior/developer/controller/RunControllerTest.java
+++ b/src/test/java/ai/junior/developer/controller/RunControllerTest.java
@@ -1,0 +1,40 @@
+package ai.junior.developer.controller;
+
+import ai.junior.developer.service.RunService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class RunControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private RunService runService;
+
+    @InjectMocks
+    private RunController runController;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        this.mockMvc = MockMvcBuilders.standaloneSetup(runController).build();
+    }
+
+    @Test
+    void testRun() throws Exception {
+        when(runService.run("someCommand")).thenReturn("Execution Result");
+
+        mockMvc.perform(post("/api/run")
+                .param("command", "someCommand"))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/ai/junior/developer/controller/ThreadControllerTest.java
+++ b/src/test/java/ai/junior/developer/controller/ThreadControllerTest.java
@@ -1,0 +1,58 @@
+package ai.junior.developer.controller;
+
+import ai.junior.developer.service.ThreadService;
+import ai.junior.developer.service.model.MessagesResponse;
+import ai.junior.developer.service.model.ThreadsResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ThreadControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private ThreadService threadService;
+
+    @InjectMocks
+    private ThreadController threadController;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        this.mockMvc = MockMvcBuilders.standaloneSetup(threadController).build();
+    }
+
+    @Test
+    void testGetThreads() throws Exception {
+        ThreadsResponse mockResponse = ThreadsResponse.builder().assistantId("assistant-id").threadId("thread-id").build();
+        when(threadService.getThreads()).thenReturn(mockResponse);
+
+        mockMvc.perform(get("/api/threads"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    void testGetMessages() throws Exception {
+        MessagesResponse messagesResponse = MessagesResponse.builder().messagesList(List.of()).build();
+        when(threadService.getMessages("123")).thenReturn(messagesResponse);
+
+        mockMvc.perform(get("/api/messages/123"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+    }
+}

--- a/src/test/java/ai/junior/developer/controller/ThreadControllerTest.java
+++ b/src/test/java/ai/junior/developer/controller/ThreadControllerTest.java
@@ -3,15 +3,12 @@ package ai.junior.developer.controller;
 import ai.junior.developer.service.ThreadService;
 import ai.junior.developer.service.model.MessagesResponse;
 import ai.junior.developer.service.model.ThreadsResponse;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.util.List;
 
@@ -20,21 +17,15 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@WebMvcTest(ThreadController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class ThreadControllerTest {
 
+    @Autowired
     private MockMvc mockMvc;
 
-    @Mock
+    @MockBean
     private ThreadService threadService;
-
-    @InjectMocks
-    private ThreadController threadController;
-
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-        this.mockMvc = MockMvcBuilders.standaloneSetup(threadController).build();
-    }
 
     @Test
     void testGetThreads() throws Exception {
@@ -43,7 +34,7 @@ class ThreadControllerTest {
 
         mockMvc.perform(get("/api/threads"))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+                .andExpect(content().contentType("application/json"));
     }
 
     @Test
@@ -53,6 +44,6 @@ class ThreadControllerTest {
 
         mockMvc.perform(get("/api/messages/123"))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+                .andExpect(content().contentType("application/json"));
     }
 }


### PR DESCRIPTION
Replaced previous controller tests with web layer tests using Spring Framework's testing features. Utilizing `@WebMvcTest` alongside `MockMvc`, all controller endpoints have been covered, including:

- FilesController
- GitController
- GitHubController
- JiraController
- MavenController
- RunController
- ThreadController

By adding `@AutoConfigureMockMvc(addFilters = false)`, tests successfully bypass security measures, offering easier, faster, and security-unaffected REST API layer coverage.