### PR TITLE
JKNIG-1-Cover controller layer with unit tests

### DIFF
--- a/src/test/java/ai/junior/developer/controller/FilesControllerTest.java
+++ b/src/test/java/ai/junior/developer/controller/FilesControllerTest.java
@@ -1,0 +1,54 @@
+package ai.junior.developer.controller;
+
+import ai.junior.developer.service.FilesService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.util.Arrays;
+
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(FilesController.class)
+class FilesControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private FilesService filesService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @WithMockUser(username="user", roles={"USER"})
+    @Test
+    void testListFiles() throws Exception {
+        when(filesService.listFiles()).thenReturn(Arrays.asList("file1.txt", "file2.txt"));
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/files/listFiles"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().string("[file1.txt, file2.txt]"));
+    }
+
+    @WithMockUser(username="user", roles={"USER"})
+    @Test
+    void testReadFile() throws Exception {
+        when(filesService.readFile("file1.txt")).thenReturn("file content");
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/files/readFile").param("filePath", "file1.txt"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().string("file content"));
+    }
+}

--- a/src/test/java/ai/junior/developer/controller/GitControllerTest.java
+++ b/src/test/java/ai/junior/developer/controller/GitControllerTest.java
@@ -1,0 +1,41 @@
+package ai.junior.developer.controller;
+
+import ai.junior.developer.service.GitService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.mockito.Mockito.verify;
+
+@WebMvcTest(GitController.class)
+class GitControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private GitService gitService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @WithMockUser(username="user", roles={"USER"})
+    @Test
+    void testCloneRepository() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/git/clone").param("repoUrl", "http://example.com/repo.git"))
+                .andExpect(MockMvcResultMatchers.status().isCreated());
+
+        verify(gitService).cloneRepository("http://example.com/repo.git");
+    }
+}

--- a/src/test/java/ai/junior/developer/controller/GitHubControllerTest.java
+++ b/src/test/java/ai/junior/developer/controller/GitHubControllerTest.java
@@ -1,0 +1,42 @@
+package ai.junior.developer.controller;
+
+import ai.junior.developer.service.GitHubService;
+import ai.junior.developer.service.GitHubWebhookService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@WebMvcTest(GitHubController.class)
+class GitHubControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private GitHubService githubService;
+
+    @MockBean
+    private GitHubWebhookService githubWebhookService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @WithMockUser(username="user", roles={"USER"})
+    @Test
+    void testCreatePullRequest() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/github/pr")
+                .param("title", "New PR")
+                .param("description", "Description")
+                .param("threadId", "1"))
+                .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+}

--- a/src/test/java/ai/junior/developer/controller/JiraControllerTest.java
+++ b/src/test/java/ai/junior/developer/controller/JiraControllerTest.java
@@ -1,0 +1,37 @@
+package ai.junior.developer.controller;
+
+import ai.junior.developer.service.JiraService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@WebMvcTest(JiraController.class)
+class JiraControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private JiraService jiraService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @WithMockUser(username="user", roles={"USER"})
+    @Test
+    void testWebhook() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/jira/webhook")
+                .header("X-Hub-Signature", "signature")
+                .content("{}"))
+                .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+}

--- a/src/test/java/ai/junior/developer/controller/MavenControllerTest.java
+++ b/src/test/java/ai/junior/developer/controller/MavenControllerTest.java
@@ -1,0 +1,36 @@
+package ai.junior.developer.controller;
+
+import ai.junior.developer.service.MavenService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@WebMvcTest(MavenController.class)
+class MavenControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private MavenService mavenService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @WithMockUser(username="user", roles={"USER"})
+    @Test
+    void testRunCleanInstall() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/build/run")
+                .param("project", "projectName"))
+                .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+}

--- a/src/test/java/ai/junior/developer/controller/RunControllerTest.java
+++ b/src/test/java/ai/junior/developer/controller/RunControllerTest.java
@@ -1,0 +1,36 @@
+package ai.junior.developer.controller;
+
+import ai.junior.developer.service.RunService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@WebMvcTest(RunController.class)
+class RunControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RunService runService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @WithMockUser(username="user", roles={"USER"})
+    @Test
+    void testRun() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/run")
+                .param("command", "ls"))
+                .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+}

--- a/src/test/java/ai/junior/developer/controller/ThreadControllerTest.java
+++ b/src/test/java/ai/junior/developer/controller/ThreadControllerTest.java
@@ -1,0 +1,37 @@
+package ai.junior.developer.controller;
+
+import ai.junior.developer.service.ThreadService;
+import ai.junior.developer.service.model.MessagesResponse;
+import ai.junior.developer.service.model.ThreadsResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@WebMvcTest(ThreadController.class)
+class ThreadControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ThreadService threadService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @WithMockUser(username="user", roles={"USER"})
+    @Test
+    void testGetThreads() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/threads"))
+                .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+}


### PR DESCRIPTION
This PR adds unit tests for the controller layer using the Spring Test framework. Security configurations were considered and each controller has a corresponding test class. The controllers covered include: FilesController, GitController, GitHubController, JiraController, MavenController, RunController, and ThreadController. The tests mock necessary services and verify endpoint functionality with proper authentication and expected responses.
ThreadId:[thread_JSvU7Axr05ji4ZjiGfdq0O8M]